### PR TITLE
New version, major rewrite that fixes HTML nesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,69 @@
-# Advanced Table of Contents 0.8.1
+# Advanced Table of Contents 0.8.2
 
-Table of contents with advanced options and customization.
+Generate a nested table of contents from page headings.
+
+* [How to install an extension](#how-to-install-an-extension)  
+* [Settings](#settings)  
+* [Styling](#styling)  
+* [How to make a table of contents](#how-to-make-a-table-of-contents) 
+  * [Best practices](#best-practices)  
+   - [Markdown](#markdown)  
+   - [Uniqueness](#uniqueness)  
+   - [Nested & sequential](#nested-sequential)  
+* [Acknowledgements](#acknowledgements)  
+* [Developer](#developer)  
+* [To do](#to-do)
 
 ## How to install an extension
 
-[Download the ZIP file](https://github.com/nevillepark/yellow-atoc/archive/main.zip) and copy it into your `system/extensions` folder. [Learn more about extensions.](https://github.com/annaesvensson/yellow-update)
-
-## How to make a table of contents
-
-Create a `[atoc]` shortcut. The table of contents is automatically generated from the headings.
+[Download the ZIP file](https://github.com/nevillepark/yellow-atoc/archive/main.zip), copy it into your `system/extensions` folder, and run `yellow.php install`. [Learn more about extensions.](https://github.com/annaesvensson/yellow-update)
 
 ## Settings
 
 The following settings can be configured in the file `system/extensions/yellow-system.ini`:
 
-`atocLevel` = the heading levels to include in tables of contents (`1` to `6`). The default is `3`.   
-`atocNumbering` = whether tables of contents should be numbered (`1`) or not (`0`).
+- `atocLevel` = the levels of headings to include in tables of contents (`2` to `6`). The default is `4`.  
+- `atocNumbering` = whether tables of contents should be numbered (`1`) or not (`0`).
 
 ## Styling
 
 By editing `system/extensions/atoc.css`, you can customize the appearance of the table of contents. You can learn more about [styling lists with CSS](https://developer.mozilla.org/en-US/docs/Learn/CSS/Styling_text/Styling_lists). Your changes will not be overwritten by future updates.
 
+## How to make a table of contents
+
+When editing a page, enter `[atoc]` where the table of contents should appear. The table of contents will be automatically generated from the headings.
+
+### Best practices
+
+For best results, your headings should be 1) in Markdown format, 2) unique, 3) properly nested, and 4) sequential. Here is [more information about properly using headings](https://www.a11yproject.com/posts/how-to-accessible-heading-structure/#best-practices-summarized). 
+
+#### Markdown
+
+Headings should be in Markdown format, e. g. `## Introduction` instead of `<h2>Introduction</h2>`. If you do want to use HTML headings, you must manually add an anchor ID, e. g. `<h2 id="introduction">Introduction</h2>`.
+
+Level 1 headings (`#`, `<h1>`) should be reserved for the website title. If you still want to use them, you will have to enter them in HTML with anchor IDs, and the table of contents will not look as nice. 
+
+#### Uniqueness
+
+If you have multiple headings with the same title (e. g., multiple sections with the heading "Instructions"), only the first one will appear in the table of contents. This applies even if the headings are different levels. To work around this, either make sure each heading is different, or write it in HTML and add a unique anchor ID. E. g., this will work:
+
+```
+### Instructions  
+  
+[…]  
+  
+<h3 id="instructions-2">Instructions</h3>  
+```
+
+#### Nested & sequential
+
+Headings should be **nested**: a section with a level 2 heading (`##`, `<h2>`) should be divided into sections with level 3 headings (`###`, `<h3>`), not the other way around. Headings should also be **sequential**: you should not skip heading levels, e. g. going from a level 2 heading to a level 4 heading. 
+
+If you don't do this, your table of contents will have gaps in it, and if it is a numbered table of contents the numbering will be off. However, it should still be usable. 
+
 ## Acknowledgements
 
-Based on [Toc](https://github.com/annaesvensson/yellow-toc/) by Anna Svensson. 
+Based on [Toc](https://github.com/annaesvensson/yellow-toc/) by Anna Svensson. Many thanks to everyone on the Fediverse who helped me with the code, especially [Phire](https://phire.place/@phire). 
 
 ## Developer
 
@@ -31,5 +71,6 @@ Neville Park. [Get help](https://datenstrom.se/yellow/help/).
 
 ## To do
 
-- [ ] [Nest lists properly](https://stackoverflow.com/questions/5899337/proper-way-to-make-html-nested-list)  
-- [ ] Make it possible to specify numbered/non-numbered ToC in a post's front matter  
+- [x] [Nest lists properly](https://stackoverflow.com/questions/5899337/proper-way-to-make-html-nested-list)  
+- [ ] Make it possible to specify numbered/non-numbered ToC in the shortcode/front matter  
+- [ ] Fix headings with the same titles as previous headings not appearing

--- a/atoc.css
+++ b/atoc.css
@@ -1,17 +1,18 @@
-/* Table of contents, with nested numbering system */
+/* Advanced Table of Contents */
 
+.atoc li li {margin: 0 0.75em;}
+
+/* Unordered (bulleted) lists */
 .atoc ul {
     list-style: disc inside;
     padding: 0;
-    margin: 0;
 }
 
+/* Ordered (numbered) lists */
 .atoc ol {
     list-style: decimal inside;
 	padding: 0;
-    margin: 0;
 }
-
 .atoc ol > li::marker {
     content: counters(list-item,".") ". ";
 }

--- a/atoc.php
+++ b/atoc.php
@@ -18,60 +18,40 @@ class YellowAtoc {
             $location = $page->getPage("main")->getLocation(true);
             $rawData = $page->getPage("main")->parserData;
             $atocLevel = $this->yellow->system->get("atocLevel");
-            // Note: this doesn't play nice when headings have the same title.
             preg_match_all("/<h([2-$atocLevel]) id=\"(.*?)\">(.*?)<\/h\d>/i", $rawData, $matches, PREG_SET_ORDER);
 
             // Variables
-            // Get list type from system settings; 0 = unordered list (<ul>), 1 = ordered list (<ol>)
             if ($this->yellow->system->get("atocNumbering")) {$listType = "ol";} else {$listType = "ul";}
             $prev = 1;
             $counter = 1;
 
             // Start list
-            $output = "<!-- AToC -->\n" . "<nav class=\"atoc\">"; // Full version
-            // $output = "<!--AToC-->\n" . "<details id=\"atoc\">\n<summary>Table of contents</summary>\n"; // Collapsible version
-			// Loop through array of matches
+            $output = "<!-- AToC -->\n" . "<nav class=\"atoc\">"; 
             foreach ($matches as $match) {
                 // Variables
                 $current = $match[1];
                 $diff = $current - $prev;
                 $entry = "<a href=\"$location#$match[2]\">$match[3]</a>";
-
-                // If current heading is below previous,
                 if ($current > $prev) {
-                    // start appropriate number of sub-lists
                     for ($i = 1; $i <= $diff; $i++) {$output .= "\n<$listType><li>";}
-                // If current heading is the same level as previous,
                 } elseif ($current == $prev) {
-                    // just close previous entry and start new entry
                     $output .= "</li>\n<li>";
-                // If current heading is above previous,
                 } elseif ($current < $prev) {
-                    // close sub-lists
                     for ($i = -1; $i >= $diff; $i--) {$output .= "</li></$listType>\n";}
-                    // close parent entry
                     $output .= "</li>\n<li>";
                 }
-
-                // Add new entry
                 $output .= "$entry";
-
-                // If last entry,
                 if ( count($matches) === $counter ) {
-                    // close sub-lists if necessary
                     for ($i = 1; $i <= $diff; $i++) {$output .= "</li></$listType>\n";}
-                    // close entry
                     $output .= "</li>";
                 }
-
-                // Before running loop again
                 $prev = $current;
                 $counter++;
             }
+
             // Close list
             $output .= "</$listType>\n";
-			$output .= "</nav>\n<!--/AToC-->"; // Full version
-			// $output .= "</details>\n<!--/AToC-->"; // Collapsible version
+			$output .= "</nav>\n<!--/AToC-->"; 
             return $output;
         };
         return preg_replace_callback("/<p>\[atoc\]<\/p>\n/i", $callback, $text);

--- a/atoc.php
+++ b/atoc.php
@@ -2,49 +2,84 @@
 // Advanced Table of Contents extension
 
 class YellowAtoc {
-    const VERSION = "0.8.1";
-    public $yellow;
+    const VERSION = "0.8.2";
+    public $yellow;     // access to API
 
+    // Initialization
     public function onLoad($yellow) {
         $this->yellow = $yellow;
-        $this->yellow->system->setDefault("atocLevel", "3");
-        $this->yellow->system->setDefault("atocNumbering", "1");
+        $this->yellow->system->setDefault("atocNumbering", "0");
+        $this->yellow->system->setDefault("atocLevel", "4");
     }
 
+    // Handle page content in HTML format
     public function onParseContentHtml($page, $text) {
         $callback = function ($matches) use ($page) {
             $location = $page->getPage("main")->getLocation(true);
             $rawData = $page->getPage("main")->parserData;
-            preg_match_all("/<h(\d) id=\"([^\"]+)\">(.*?)<\/h\d>/i", $rawData, $matches, PREG_SET_ORDER);
-            if ( $this->yellow->system->get("atocNumbering")) {
-                $listType = "ol";
-            } else {
-                $listType = "ul";
-            }
-            $output = "<$listType class=\"atoc\">";
-            $prevLevel = $nestedList = 0;
+            $atocLevel = $this->yellow->system->get("atocLevel");
+            // Note: this doesn't play nice when headings have the same title.
+            preg_match_all("/<h([2-$atocLevel]) id=\"(.*?)\">(.*?)<\/h\d>/i", $rawData, $matches, PREG_SET_ORDER);
+
+            // Variables
+            // Get list type from system settings; 0 = unordered list (<ul>), 1 = ordered list (<ol>)
+            if ($this->yellow->system->get("atocNumbering")) {$listType = "ol";} else {$listType = "ul";}
+            $prev = 1;
+            $counter = 1;
+
+            // Start list
+            $output = "<!-- AToC -->\n" . "<nav class=\"atoc\">"; // Full version
+            // $output = "<!--AToC-->\n" . "<details id=\"atoc\">\n<summary>Table of contents</summary>\n"; // Collapsible version
+			// Loop through array of matches
             foreach ($matches as $match) {
-                if ($match[1] < $prevLevel) {
-                    $nestedList = 0;
-                    $output .= "</$listType>";
-                } elseif ($prevLevel != 0 && $match[1] > $prevLevel) {
-                    ++$nestedList;
-                    $output .= "<$listType>";
+                // Variables
+                $current = $match[1];
+                $diff = $current - $prev;
+                $entry = "<a href=\"$location#$match[2]\">$match[3]</a>";
+
+                // If current heading is below previous,
+                if ($current > $prev) {
+                    // start appropriate number of sub-lists
+                    for ($i = 1; $i <= $diff; $i++) {$output .= "\n<$listType><li>";}
+                // If current heading is the same level as previous,
+                } elseif ($current == $prev) {
+                    // just close previous entry and start new entry
+                    $output .= "</li>\n<li>";
+                // If current heading is above previous,
+                } elseif ($current < $prev) {
+                    // close sub-lists
+                    for ($i = -1; $i >= $diff; $i--) {$output .= "</li></$listType>\n";}
+                    // close parent entry
+                    $output .= "</li>\n<li>";
                 }
-                $output .= "<li><a href=\"$location#$match[2]\">$match[3]</a></li>\n";
-                $prevLevel = $match[1];
+
+                // Add new entry
+                $output .= "$entry";
+
+                // If last entry,
+                if ( count($matches) === $counter ) {
+                    // close sub-lists if necessary
+                    for ($i = 1; $i <= $diff; $i++) {$output .= "</li></$listType>\n";}
+                    // close entry
+                    $output .= "</li>";
+                }
+
+                // Before running loop again
+                $prev = $current;
+                $counter++;
             }
-            for ($i = 0; $i < $nestedList; $i++) {
-                $output .= "</$listType>\n";
-            }
+            // Close list
             $output .= "</$listType>\n";
+			$output .= "</nav>\n<!--/AToC-->"; // Full version
+			// $output .= "</details>\n<!--/AToC-->"; // Collapsible version
             return $output;
         };
         return preg_replace_callback("/<p>\[atoc\]<\/p>\n/i", $callback, $text);
     }
-
+    // Handle page extra data
     public function onParsePageExtra($page, $name) {
         $output = null;
+        // Add stylesheet
         if ($name=="header") {
             $extensionLocation = $this->yellow->system->get("coreServerBase").$this->yellow->system->get("coreExtensionLocation");
             $output = "<link rel=\"stylesheet\" type=\"text/css\" media=\"all\" href=\"{$extensionLocation}atoc.css\" />\n";

--- a/extension.ini
+++ b/extension.ini
@@ -1,11 +1,11 @@
 # Datenstrom Yellow extension settings
 
 Extension: Advanced ToC
-Version: 0.8.1
-Description: Table of contents with advanced options and customization.
+Version: 0.8.2
+Description: Generate a nested table of contents from page headings.
 DocumentationUrl: https://github.com/nevillepark/yellow-atoc
 DownloadUrl: https://github.com/nevillepark/yellow-atoc/archive/main.zip
-Published: 2023-04-03 03:08:00
+Published: 2024-01-02 17:37:00
 Developer: Neville Park
 Tag: feature
 system/extensions/atoc.php: atoc.php, create, update


### PR DESCRIPTION
Previously this generated incorrectly nested HTML lists. It now produces lists correctly nested _within_ a parent `<li>` element. The feature to specify the maximum heading depth to include also works now. 

It deals with skipped heading levels by generating empty `<$listType><li>` elements as necessary. The README explains how to use headings properly to get a better-presented table of contents, and also how to work around certain limitations. 