### PR TITLE
Change preg_match_all flag

### DIFF
--- a/atoc.css
+++ b/atoc.css
@@ -1,18 +1,13 @@
 /* Advanced Table of Contents */
 
+/* Play nice with yellow-anchor extension */
+.atoc a.anchor-link {display: none;}
+
 .atoc li li {margin: 0 0.75em;}
 
 /* Unordered (bulleted) lists */
-.atoc ul {
-    list-style: disc inside;
-    padding: 0;
-}
+.atoc ul {list-style: disc inside; padding: 0;}
 
 /* Ordered (numbered) lists */
-.atoc ol {
-    list-style: decimal inside;
-	padding: 0;
-}
-.atoc ol > li::marker {
-    content: counters(list-item,".") ". ";
-}
+.atoc ol {list-style: decimal inside; padding: 0;}
+.atoc ol > li::marker {content: counters(list-item,".") ". ";}

--- a/atoc.php
+++ b/atoc.php
@@ -2,7 +2,7 @@
 // Advanced Table of Contents extension
 
 class YellowAtoc {
-    const VERSION = "0.9";
+    const VERSION = "0.8.2";
     public $yellow;     // access to API
 
     // Initialization

--- a/atoc.php
+++ b/atoc.php
@@ -18,67 +18,52 @@ class YellowAtoc {
             $location = $page->getPage("main")->getLocation(true);
             $rawData = $page->getPage("main")->parserData;
             $atocLevel = $this->yellow->system->get("atocLevel");
-            // Note: this doesn't play nice when headings have the same title.
-            // Also note: to allow <h1> headings in ToC, change "2-$atocLevel" 
-            // to "1-$atocLevel" (but you shouldn't)
-            preg_match_all("/<h([2-$atocLevel]) id=\"(.*?)\">(.*?)<\/h\d>/i", $rawData, $matches, PREG_PATTERN_ORDER);
+
+            preg_match_all("/<h([1-$atocLevel]) id=\"(.*?)\">(.*?)<\/h\d>/i", $rawData, $matches, PREG_PATTERN_ORDER);
 
             // Variables
-            // Get list type from system settings
-            // 0 = unordered list (<ul>), 1 = ordered list (<ol>)
             if ($this->yellow->system->get("atocNumbering")) {$listType = "ol";} else {$listType = "ul";}
-            // Just to make things easier
             $level = $matches[1];
             $anchor = $matches[2];
             $title = $matches[3];
-            // Counting variables
             $min = min($level);
             $count = count($level);
             $prev = $min - 1;
             $counter = 0;
 
-            // Start table of contents
-            $output = "<nav class=\"atoc\">"; // Nav version
-            // $output = "<!--AToC-->\n" . "<details id=\"atoc\">\n<summary>Table of contents</summary>\n"; // Collapsible version
-            // Start loop 
+            // Start list
+            $output = "<!-- AToC -->" . "<nav class=\"atoc\">";
             for ( $a = $counter; $a < $count; $a++ ) {
                 // Variables
                 $current = $level[$a];
                 $diff = $current - $prev;
                 $entry = "<a href=\"$location#$anchor[$a]\">$title[$a]</a>";
-                // If current heading is below previous,
+
                 if ($current > $prev) {
-                    // start appropriate number of sub-lists 
                     for ($i = 1; $i <= $diff; $i++) {$output .= "\n<$listType><li>";}
-                // If current heading is the same level as previous,
                 } elseif ($current == $prev) {
-                    // close previous entry and start new entry,
                     $output .= "</li>\n<li>";
                 } elseif ( $current < $prev ) {
-                    // close sub-lists,
                     for ($i = -1; $i >= $diff; $i--) {$output .= "</li></$listType>\n";}
-                    // and close parent entry
                     $output .= "</li>\n<li>";
                 }
-                // Print entry
+
                 $output .= "$entry";
-                // If last entry
+
                 if ($a == $count - 1) {
                  for ($i = 1; $i <= $diff; $i++) {$output .= "</li></$listType>\n";}
-                    // close entry
                     $output .= "</li>";
                 }
-                // Before next loop
                 $prev = $current;
-            } // end loop
-            // End list
+            }
+            
+            // Close list
             $output .= "</$listType>\n";
-            $output .= "</nav>"; // Nav version
-            // $output .= "</details>\n<!--/AToC-->"; // Collapsible version
+            $output .= "</nav>" . "<!-- /AToC -->"; 
             return $output;
-        }; // end callback
+        }; 
         return preg_replace_callback("/<p>\[atoc\]<\/p>\n/i", $callback, $text);
-    } // end OnParseContentHtml function
+    } 
     // Handle page extra data
     public function onParsePageExtra($page, $name) {
         $output = null;

--- a/atoc.php
+++ b/atoc.php
@@ -18,40 +18,60 @@ class YellowAtoc {
             $location = $page->getPage("main")->getLocation(true);
             $rawData = $page->getPage("main")->parserData;
             $atocLevel = $this->yellow->system->get("atocLevel");
+            // Note: this doesn't play nice when headings have the same title.
             preg_match_all("/<h([2-$atocLevel]) id=\"(.*?)\">(.*?)<\/h\d>/i", $rawData, $matches, PREG_SET_ORDER);
 
             // Variables
+            // Get list type from system settings; 0 = unordered list (<ul>), 1 = ordered list (<ol>)
             if ($this->yellow->system->get("atocNumbering")) {$listType = "ol";} else {$listType = "ul";}
             $prev = 1;
             $counter = 1;
 
             // Start list
-            $output = "<!-- AToC -->\n" . "<nav class=\"atoc\">"; 
+            $output = "<!-- AToC -->\n" . "<nav class=\"atoc\">"; // Full version
+            // $output = "<!--AToC-->\n" . "<details id=\"atoc\">\n<summary>Table of contents</summary>\n"; // Collapsible version
+			// Loop through array of matches
             foreach ($matches as $match) {
                 // Variables
                 $current = $match[1];
                 $diff = $current - $prev;
                 $entry = "<a href=\"$location#$match[2]\">$match[3]</a>";
+
+                // If current heading is below previous,
                 if ($current > $prev) {
+                    // start appropriate number of sub-lists
                     for ($i = 1; $i <= $diff; $i++) {$output .= "\n<$listType><li>";}
+                // If current heading is the same level as previous,
                 } elseif ($current == $prev) {
+                    // just close previous entry and start new entry
                     $output .= "</li>\n<li>";
+                // If current heading is above previous,
                 } elseif ($current < $prev) {
+                    // close sub-lists
                     for ($i = -1; $i >= $diff; $i--) {$output .= "</li></$listType>\n";}
+                    // close parent entry
                     $output .= "</li>\n<li>";
                 }
+
+                // Add new entry
                 $output .= "$entry";
+
+                // If last entry,
                 if ( count($matches) === $counter ) {
+                    // close sub-lists if necessary
                     for ($i = 1; $i <= $diff; $i++) {$output .= "</li></$listType>\n";}
+                    // close entry
                     $output .= "</li>";
                 }
+
+                // Before running loop again
                 $prev = $current;
                 $counter++;
             }
-
             // Close list
             $output .= "</$listType>\n";
-			$output .= "</nav>\n<!--/AToC-->"; 
+			$output .= "</nav>\n<!--/AToC-->"; // Full version
+			// $output .= "</details>\n<!--/AToC-->"; // Collapsible version
             return $output;
         };
         return preg_replace_callback("/<p>\[atoc\]<\/p>\n/i", $callback, $text);

--- a/atoc.php
+++ b/atoc.php
@@ -72,7 +72,7 @@ class YellowAtoc {
                 $prev = $current;
             } // end loop
             // End list
-            $output .= "</$listType>\n"
+            $output .= "</$listType>\n";
             $output .= "</nav>"; // Nav version
             // $output .= "</details>\n<!--/AToC-->"; // Collapsible version
             return $output;


### PR DESCRIPTION
Fixes issue with unnecessary list nesting if all headings were <h3> and lower; this made it easier to figure out the highest heading level and adjust variables accordingly. 